### PR TITLE
support required_labels rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,8 @@ clusters:
     # - default: <bool>, use when no match other rules
     # - start: <op duration>, compare `start` at request parameter
     # - end: <op duration>, compare `end` at request parameter
-    # - range: <op duration>, range is between `start` and `end` at request parameter.
+    # - range: <op duration>, range is between `start` and `end` at request parameter
+    # - required_labels: [ <label_name>: <label_value> ... ], find labels from `query` or `match[]` parameter(s)
     rules:
       [ - <rules>, ...]
 ```

--- a/pkg/config/sample.yml
+++ b/pkg/config/sample.yml
@@ -18,6 +18,9 @@ clusters:
     rules:
       - target: primary
         default: true
+      - target: primary
+        required_labels:
+          job: foo
       - target: archive
         range: "> 1d"
       - target: archive

--- a/pkg/dispatcher/dispatcher.go
+++ b/pkg/dispatcher/dispatcher.go
@@ -102,15 +102,19 @@ func (d Dispatcher) FindNode(in Input) *model.Node {
 		}
 		if len(rule.RequiredLabels) != 0 {
 			if len(in.Query) != 0 {
-				inMatchers, err := promql.ParseMetricSelector(in.Query)
-				if err != nil {
-					// FIXME: logging
-				}
-				if satisfy(inMatchers, rule.RequiredLabels) {
-					return d.resolveNode(rule.Target)
+				if inMatchers, err := promql.ParseMetricSelector(in.Query); err == nil {
+					if satisfy(inMatchers, rule.RequiredLabels) {
+						return d.resolveNode(rule.Target)
+					}
 				}
 			}
-			// TODO: support in.Matchers
+			for _, matcher := range in.Matchers {
+				if inMatchers, err := promql.ParseMetricSelector(matcher); err == nil {
+					if satisfy(inMatchers, rule.RequiredLabels) {
+						return d.resolveNode(rule.Target)
+					}
+				}
+			}
 		}
 	}
 	return d.defaultNode()

--- a/pkg/model/base.go
+++ b/pkg/model/base.go
@@ -1,6 +1,7 @@
 package model
 
 import (
+	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/pkg/relabel"
 )
 
@@ -17,10 +18,11 @@ type Node struct {
 }
 
 type Rule struct {
-	Target  string           `yaml:"target"`
-	Default bool             `yaml:"default"`
-	Range   DurationCriteria `yaml:"range"`
-	Time    TimeCriteria     `yaml:"time"`
-	Start   TimeCriteria     `yaml:"start"`
-	End     TimeCriteria     `yaml:"end"`
+	Target         string           `yaml:"target"`
+	Default        bool             `yaml:"default"`
+	Range          DurationCriteria `yaml:"range"`
+	Time           TimeCriteria     `yaml:"time"`
+	Start          TimeCriteria     `yaml:"start"`
+	End            TimeCriteria     `yaml:"end"`
+	RequiredLabels model.LabelSet   `yaml:"required_labels"`
 }


### PR DESCRIPTION
This feature enables to dispatch requests that contain specific labels.
Config interface refers to `remote_read` > `required_matchers` of prometheus.