### PR TITLE
ensure min step

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM quay.io/prometheus/busybox:latest
 LABEL maintainer="kobtea9696@gmail.com"
 
 COPY pkg/config/sample.yml /etc/iapetus.yml
-COPY dist/linux_amd64/iapetus /bin/iapetus
+COPY dist/iapetus_linux_amd64/iapetus /bin/iapetus
 
 EXPOSE 19090
 ENTRYPOINT ["/bin/iapetus"]

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ clusters:
         relabels:
           # support relabelling rules at prometheus
           [ - <relabel_config> ... ]
+        min_step: <duration>
     # proxy rules
     # each rule are pair of `target: <node_name>` and some rule.
     # support rules are below.
@@ -89,6 +90,7 @@ clusters:
           - source_labels: [__name__]
             target_label: __name__
             replacement: ${1}_avg
+        min_step: 10m
     rules:
       - target: primary
         default: true

--- a/pkg/model/base.go
+++ b/pkg/model/base.go
@@ -15,6 +15,7 @@ type Node struct {
 	Name     string            `yaml:"name"`
 	Url      string            `yaml:"url"`
 	Relabels []*relabel.Config `yaml:"relabels"`
+	MinStep  model.Duration    `yaml:"min_step"`
 }
 
 type Rule struct {

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -16,6 +16,7 @@ import (
 	"path"
 	"regexp"
 	"strings"
+	"time"
 )
 
 const headerRequestError = "X-Iapetus-Request-Error"
@@ -97,6 +98,12 @@ func NewProxyHandler(config config.Config) (http.Handler, error) {
 					return
 				}
 				values.Add("match[]", in.Matchers[i])
+			}
+		}
+		if origStep := values.Get("step"); origStep != "" {
+			step, err := util.ParseDuration(origStep)
+			if err == nil && step < time.Duration(node.MinStep) {
+				values.Set("step", node.MinStep.String())
 			}
 		}
 


### PR DESCRIPTION
Ensure min step like a "scrape interval" in Prometheus datasource.

refs
- https://grafana.com/blog/2020/09/28/new-in-grafana-7.2-__rate_interval-for-prometheus-rate-queries-that-just-work/
- https://grafana.com/docs/grafana/latest/datasources/prometheus/#using-__rate_interval-variable